### PR TITLE
A few fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = space
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text eol=lf

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -7,6 +7,11 @@ temp = require 'temp'
 XRegExp = require('xregexp').XRegExp
 
 class Linter
+  name: 'haml_lint'
+  grammarScopes: ['text.haml']
+  scope: 'file'
+  lintOnFly: true
+
   constructor: ->
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-haml.copyRubocopYml', (copyRubocopYml) =>
@@ -47,8 +52,6 @@ class Linter
       @findFile filePath, '.rubocop.yml'
       .then (rubocopYmlPath) ->
         resolve rubocopYmlPath
-
-  grammarScopes: ['text.haml']
 
   lint: (textEditor) =>
     new Promise (resolve, reject) =>
@@ -108,7 +111,6 @@ class Linter
             range: helpers.rangeFromLineNumber(textEditor, match.line - 1)
         return messages
 
-  lintOnFly: true
 
   makeTempDir: ->
     new Promise (resolve, reject) ->
@@ -122,7 +124,6 @@ class Linter
         return reject Error(error) if error
         resolve()
 
-  scope: 'file'
 
   writeTempFile: (tempDir, fileName, fileContent) ->
     new Promise (resolve, reject) ->

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -27,7 +27,7 @@ class Linter
 
   findFile: (filePath, fileName) =>
     new Promise (resolve, reject) =>
-      foundPath = helpers.findFile filePath, fileName
+      foundPath = helpers.find filePath, fileName
       return resolve foundPath if foundPath
 
       homeDir = process.env.HOME || process.env.USERPROFILE

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -87,7 +87,6 @@ class Linter
   lintFile: (textEditor, tempFile, hamlLintYmlPath) ->
     new Promise (resolve, reject) =>
       filePath   = textEditor.getPath()
-      tabLength  = textEditor.getTabLength()
       textBuffer = textEditor.getBuffer()
 
       args = []
@@ -110,15 +109,11 @@ class Linter
             '(?<message>.+)'
           messages = []
           XRegExp.forEach output, regex, (match, i) ->
-            indentLevel = textEditor.indentationForBufferRow(match.line - 1)
             messages.push
               type: if match.warning? then 'warning' else 'error'
               text: match.message
               filePath: filePath
-              range: [
-                [match.line - 1, indentLevel * tabLength],
-                [match.line - 1, textBuffer.lineLengthForRow(match.line - 1)]
-              ]
+              range: helpers.rangeFromLineNumber(textEditor, match.line - 1)
           resolve messages
 
   lintOnFly: true

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -13,6 +13,7 @@ class Linter
   lintOnFly: true
 
   constructor: ->
+    require('atom-package-deps').install()
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-haml.copyRubocopYml', (copyRubocopYml) =>
       @copyRubocopYml = copyRubocopYml

--- a/package.json
+++ b/package.json
@@ -7,14 +7,18 @@
   "repository": "https://github.com/AtomLinter/linter-haml",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.151.0"
+    "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
     "atom-linter": "^4.2.0",
+    "atom-package-deps": "^3.0.6",
     "fs-extra": "0.26.3",
     "temp": "0.8.3",
     "xregexp": "3.0.0"
   },
+  "package-deps": [
+    "linter"
+  ],
   "providedServices": {
     "linter": {
       "versions": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "atom": ">=0.151.0"
   },
   "dependencies": {
-    "atom-linter": "4.2.0",
+    "atom-linter": "^4.2.0",
     "fs-extra": "0.26.3",
     "temp": "0.8.3",
     "xregexp": "3.0.0"


### PR DESCRIPTION
This PR does a few things:

* Update to atom-linter v4 API
* Use rangeFromLineNumber to generate the ranges for line highlighting
* Use helpers.exec to run the program instead of using Atom's BufferedProcess (directly)
* Specify a name for the linter so its messages can be identified
* Automatically install linter

This _should_ fix #14 since helpers.rangeFromLineNumber works around the Atom bug that is triggering that message.
Fixes #15.