### PR TITLE
Add specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "xregexp": "3.1.0"
   },
   "package-deps": [
-    "linter"
+    "linter",
+    "language-haml"
   ],
   "providedServices": {
     "linter": {

--- a/package.json
+++ b/package.json
@@ -25,5 +25,24 @@
         "1.0.0": "provideLinter"
       }
     }
+  },
+  "devDependencies": {
+    "eslint": "^2.2.0",
+    "babel-eslint": "^5.0.0",
+    "eslint-config-airbnb": "^6.0.2"
+  },
+  "eslintConfig": {
+    "rules": {
+      "comma-dangle": [2, "never"]
+    },
+    "extends": "airbnb/base",
+    "parser": "babel-eslint",
+    "globals": {
+      "atom": true
+    },
+    "env": {
+      "es6": true,
+      "node": true
+    }
   }
 }

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,0 +1,8 @@
+module.exports = {
+  'globals': {
+    'waitsForPromise': true
+  },
+  'env': {
+    'jasmine': true
+  }
+};

--- a/spec/fixtures/cawsv.rb
+++ b/spec/fixtures/cawsv.rb
@@ -1,0 +1,1 @@
+%tag{ class: 'status' }

--- a/spec/fixtures/valid.rb
+++ b/spec/fixtures/valid.rb
@@ -1,0 +1,1 @@
+%tag.class

--- a/spec/linter-haml-spec.js
+++ b/spec/linter-haml-spec.js
@@ -1,0 +1,76 @@
+'use babel';
+
+import * as path from 'path';
+
+const validPath = path.join(__dirname, 'fixtures', 'valid.rb');
+const cawsvpath = path.join(__dirname, 'fixtures', 'cawsv.rb');
+const emptyPath = path.join(__dirname, 'fixtures', 'empty.rb');
+
+describe('The haml-lint provider for Linter', () => {
+  const Linter = require(path.join('..', 'lib', 'linter'));
+  const lint = new Linter().lint;
+
+  beforeEach(() => {
+    atom.workspace.destroyActivePaneItem();
+    if (!atom.packages.isPackageDisabled('language-ruby')) {
+      atom.packages.disablePackage('language-ruby');
+    }
+    waitsForPromise(() =>
+      atom.packages.activatePackage('linter-haml').then(() =>
+        atom.packages.activatePackage('language-haml').then(() =>
+          atom.workspace.open(validPath)
+        )
+      )
+    );
+  });
+
+  describe('checks a file with issues and', () => {
+    let editor = null;
+    beforeEach(() => {
+      waitsForPromise(() =>
+        atom.workspace.open(cawsvpath).then(openEditor => { editor = openEditor; })
+      );
+    });
+
+    it('finds at least one message', () => {
+      waitsForPromise(() =>
+        lint(editor).then(messages =>
+          expect(messages.length).toBeGreaterThan(0)
+        )
+      );
+    });
+
+    it('verifies the first message', () => {
+      waitsForPromise(() => {
+        const messageText = 'ClassAttributeWithStaticValue: Avoid defining ' +
+          '`class` in attributes hash for static class names';
+        return lint(editor).then(messages => {
+          expect(messages[0].type).toEqual('Warning');
+          expect(messages[0].text).toEqual(messageText);
+          expect(messages[0].filePath).toBe(cawsvpath);
+          expect(messages[0].range).toEqual([[0, 0], [0, 23]]);
+        });
+      });
+    });
+  });
+
+  it('finds nothing wrong with a valid file', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(validPath).then(editor =>
+        lint(editor).then(messages =>
+          expect(messages.length).toEqual(0)
+        )
+      )
+    );
+  });
+
+  it('finds nothing wrong with an empty file', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(emptyPath).then(editor =>
+        lint(editor).then(messages =>
+          expect(messages.length).toEqual(0)
+        )
+      )
+    );
+  });
+});


### PR DESCRIPTION
Add some basic specs to test the functionality of the linter.

Currently doesn't test configuration file handling.

Fixes #28.