### PR TITLE
Fix findHamLintYmlFile method because it doesn't find the .haml-lint.yml file

### DIFF
--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -48,8 +48,8 @@ class Linter
     new Promise (resolve, reject) =>
       @findFile filePath, '.haml-lint.yml'
       .then (hamlLintYmlPath) =>
-        if hamlLintYmlPath is undefined
-          hamlLintYmlPath = @findFile filePath, @globalHamlLintFile
+        if hamlLintYmlPath is undefined and @exists @globalHamlLintFile
+          hamlLintYmlPath = @globalHamlLintFile
         resolve hamlLintYmlPath
 
   findRubocopYmlFile: (filePath) =>
@@ -63,7 +63,6 @@ class Linter
       fileContent = textEditor.getText()
       filePath = textEditor.getPath()
       fileName = path.basename filePath
-      projectPath = "#{atom.project.relativizePath(filePath)[0]}/"
 
       results = []
       rubocopYmlPath = undefined
@@ -80,7 +79,7 @@ class Linter
         if rubocopYmlPath
           @copyFile rubocopYmlPath, path.join(tempDir, '.rubocop.yml')
       .then =>
-        @findHamlLintYmlFile(projectPath)
+        @findHamlLintYmlFile filePath
       .then (hamlLintYmlPath) =>
         @lintFile textEditor, tempFile, hamlLintYmlPath
       .then (messages) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -15,6 +15,11 @@ module.exports =
       description: 'Path to haml-lint executable'
       type: 'string'
 
+    globalHamlLintYmlFile:
+      default: '.haml-lint.yml'
+      description: 'Path to set the global haml lint file'
+      type: 'string'
+      
   deactivate: =>
     @linter.subscriptions.dispose()
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,10 +16,9 @@ module.exports =
       type: 'string'
 
     globalHamlLintYmlFile:
-      default: '.haml-lint.yml'
-      description: 'Path to set the global haml lint file'
+      description: 'Full path to a global Haml lint file, if no other is found'
       type: 'string'
-      
+
   deactivate: =>
     @linter.subscriptions.dispose()
 


### PR DESCRIPTION
Additionally adds the "global haml lint file" functionality if user just wants
to have a global file