### PR TITLE
Move to eslint-config-airbnb-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,20 +27,20 @@
       }
     }
   },
+  "scripts": {
+    "test": "apm test",
+    "lint": "eslint ."
+  },
   "devDependencies": {
     "eslint": "^2.8.0",
-    "eslint-config-airbnb": "^7.0.0",
-    "eslint-plugin-react": "^4.3.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2"
+    "eslint-config-airbnb-base": "^1.0.2",
+    "eslint-plugin-import": "^1.5.0"
   },
   "eslintConfig": {
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ]
+      "comma-dangle": [2, "never"]
     },
-    "extends": "airbnb/base",
+    "extends": "airbnb-base",
     "globals": {
       "atom": true
     },

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  'globals': {
-    'waitsForPromise': true
-  },
   'env': {
-    'jasmine': true
+    'jasmine': true,
+    'atomtest': true
   }
 };

--- a/spec/linter-haml-spec.js
+++ b/spec/linter-haml-spec.js
@@ -6,8 +6,9 @@ const validPath = path.join(__dirname, 'fixtures', 'valid.rb');
 const cawsvpath = path.join(__dirname, 'fixtures', 'cawsv.rb');
 const emptyPath = path.join(__dirname, 'fixtures', 'empty.rb');
 
+const Linter = require(path.join('..', 'lib', 'linter'));
+
 describe('The haml-lint provider for Linter', () => {
-  const Linter = require(path.join('..', 'lib', 'linter'));
   const lint = new Linter().lint;
 
   beforeEach(() => {


### PR DESCRIPTION
This package has no need of the React components included in eslint-config-airbnb.

Closes #67.
Closes #71.