### PR TITLE
Cleanup the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
-linter-haml
-=========================
+# linter-haml
 
 [![Build Status](https://travis-ci.org/AtomLinter/linter-haml.svg?branch=master)](https://travis-ci.org/AtomLinter/linter-haml)
 
-This linter plugin for [Linter](https://github.com/AtomLinter/Linter) provides an interface to [haml-lint](https://github.com/causes/haml-lint). It will be used with files that have the "HAML" syntax.
+This linter plugin for [Linter][] provides
+an interface to [haml-lint][]. It will be
+used with files that have the "HAML" syntax.
 
 ## Installation
 
 ### Dependencies
 
-This plugin requires the Linter package to be installed. If Linter is not installed, please follow the instructions [here](https://atom.io/packages/linter).
+This plugin requires a separate package to be installed to run it and provide
+an interface. If [Linter][] is not
+installed already, it will be installed for you to provide this.
 
-Linter-haml relies on the HAML-lint gem to perform linting. If you do not currently have HAML-lint installed, follow the instructions [here](https://github.com/causes/haml-lint).
+Linter-haml relies on the HAML-lint gem to perform linting. If you do not
+currently have HAML-lint installed, follow the instructions [here][haml-lint].
 
-You may also need to install the [language-haml](https://github.com/cannikin/language-haml) plugin.
+As Atom doesn't include a HAML language by default, [language-haml][]
+will be installed for you if it isn't already. You will likely want to disable
+`language-ruby` as it will mark all files as Ruby before `language-haml`.
+
+If you prefer an alternative to any of the above packages that are installed
+for you, simply disable them.
 
 ### Plugin installation
 ```
@@ -21,18 +30,19 @@ $ apm install linter-haml
 ```
 
 ## Settings
-You can configure linter-haml by editing ~/.atom/config.cson (choose Open Your Config in Atom menu):
-```
-'linter-haml':
-  'copyRubocopYml': true # Copy rubocop.yml to temporary directory for linting (if it can be found).  Set to `false` if this is too slow / too IO-intensive for your needs.
-  'hamlLintExecutablePath': null # haml-lint path.  Run `which haml-lint` to find the path.
-```
+
+`linter-haml` can be configured from Atom's Settings menu in the Packages
+section. All available options are shown there.
 
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 
-1. Fork the plugin repository.
-1. Hack on a separate topic branch created from the latest `master`.
-1. Commit and push the topic branch.
-1. Make a pull request.
-1. welcome to the club
+1.  Fork the plugin repository.
+2.  Hack on a separate topic branch created from the latest `master`.
+3.  Commit and push the topic branch.
+4.  Make a pull request.
+5.  welcome to the club
+
+[linter]: https://atom.io/packages/linter
+[haml-lint]: https://github.com/causes/haml-lint
+[language-haml]: https://atom.io/packages/language-haml


### PR DESCRIPTION
* Fix several issues exposed by `remark-lint`
* Fix links
* Note that `linter` and `language-haml` will be installed for you