### PR TITLE
Update eslint-config-airbnb-base to 10.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,15 @@ matrix:
       env: ATOM_CHANNEL=stable
 
     - os: linux
-      rvm: 2.2.5
+      rvm: 2.2.6
       env: ATOM_CHANNEL=stable
 
     - os: linux
-      rvm: 2.3.1
+      rvm: 2.3.3
       env: ATOM_CHANNEL=stable
 
     - os: linux
-      rvm: 2.3.1
+      rvm: 2.3.3
       env: ATOM_CHANNEL=beta
 
 env:

--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,7 @@ import { dirname } from 'path';
 let executablePath;
 let globalHamlLintYmlFile;
 
-const regex = /.+?:(\d+) \[(W|E)\] (\w+): (.+)/g;
+const regex = /.+?:(\d+) \[(W|E)] (\w+): (.+)/g;
 const urlBase = 'https://github.com/brigade/haml-lint/blob/master/lib/haml_lint/linter/README.md';
 
 export default {
@@ -22,12 +22,12 @@ export default {
     this.subscriptions.add(
       atom.config.observe('linter-haml.executablePath', (value) => {
         executablePath = value;
-      })
+      }),
     );
     this.subscriptions.add(
       atom.config.observe('linter-haml.globalHamlLintYmlFile', (value) => {
         globalHamlLintYmlFile = value;
-      })
+      }),
     );
   },
 

--- a/package.json
+++ b/package.json
@@ -42,11 +42,12 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "eslint": "^3.6.0",
-    "eslint-config-airbnb-base": "^8.0.0",
-    "eslint-plugin-import": "^1.16.0"
+    "eslint": "^3.9.1",
+    "eslint-config-airbnb-base": "^10.0.1",
+    "eslint-plugin-import": "^2.1.0"
   },
   "eslintConfig": {
+    "extends": "airbnb-base",
     "rules": {
       "global-require": "off",
       "import/no-unresolved": [
@@ -58,7 +59,6 @@
         }
       ]
     },
-    "extends": "airbnb-base",
     "globals": {
       "atom": true
     },

--- a/spec/linter-haml-spec.js
+++ b/spec/linter-haml-spec.js
@@ -19,8 +19,8 @@ describe('The haml-lint provider for Linter', () => {
         atom.packages.activatePackage('linter-haml'),
         atom.packages.activatePackage('language-haml'),
       ]).then(() =>
-        atom.workspace.open(validPath)
-      )
+        atom.workspace.open(validPath),
+      ),
     );
   });
 
@@ -28,15 +28,15 @@ describe('The haml-lint provider for Linter', () => {
     let editor = null;
     beforeEach(() => {
       waitsForPromise(() =>
-        atom.workspace.open(cawsvpath).then((openEditor) => { editor = openEditor; })
+        atom.workspace.open(cawsvpath).then((openEditor) => { editor = openEditor; }),
       );
     });
 
     it('finds at least one message', () => {
       waitsForPromise(() =>
         lint(editor).then(messages =>
-          expect(messages.length).toBeGreaterThan(0)
-        )
+          expect(messages.length).toBeGreaterThan(0),
+        ),
       );
     });
 
@@ -61,9 +61,9 @@ describe('The haml-lint provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(validPath).then(editor =>
         lint(editor).then(messages =>
-          expect(messages.length).toBe(0)
-        )
-      )
+          expect(messages.length).toBe(0),
+        ),
+      ),
     );
   });
 
@@ -71,9 +71,9 @@ describe('The haml-lint provider for Linter', () => {
     waitsForPromise(() =>
       atom.workspace.open(emptyPath).then(editor =>
         lint(editor).then(messages =>
-          expect(messages.length).toBe(0)
-        )
-      )
+          expect(messages.length).toBe(0),
+        ),
+      ),
     );
   });
 });


### PR DESCRIPTION
Updates `eslint-config-airbnb-base` to 10.0.1.

Also updates the following to satisfy the peerDependency requirements:
* `eslint@^3.9.1`
* `eslint-plugin-import@^2.1.0`

Closes #115.
Closes #116.