### PR TITLE
Asyncify the specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "devDependencies": {
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
-    "eslint-plugin-import": "^2.7.0"
+    "eslint-plugin-import": "^2.7.0",
+    "jasmine-fix": "^1.3.0"
   },
   "eslintConfig": {
     "extends": "airbnb-base",

--- a/spec/linter-haml-spec.js
+++ b/spec/linter-haml-spec.js
@@ -1,5 +1,7 @@
 'use babel';
 
+// eslint-disable-next-line no-unused-vars
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 import * as path from 'path';
 
 const validPath = path.join(__dirname, 'fixtures', 'valid.rb');
@@ -9,60 +11,42 @@ const emptyPath = path.join(__dirname, 'fixtures', 'empty.rb');
 const { lint } = require('../lib/main.js').provideLinter();
 
 describe('The haml-lint provider for Linter', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     atom.workspace.destroyActivePaneItem();
     if (!atom.packages.isPackageDisabled('language-ruby')) {
       atom.packages.disablePackage('language-ruby');
     }
-    waitsForPromise(() =>
-      Promise.all([
-        atom.packages.activatePackage('linter-haml'),
-        atom.packages.activatePackage('language-haml'),
-      ]).then(() =>
-        atom.workspace.open(validPath)));
+    await atom.packages.activatePackage('linter-haml');
+    await atom.packages.activatePackage('language-haml');
   });
 
-  describe('checks a file with issues and', () => {
-    let editor = null;
-    beforeEach(() => {
-      waitsForPromise(() =>
-        atom.workspace.open(cawsvpath).then((openEditor) => { editor = openEditor; }));
-    });
+  it('checks a file with issues', async () => {
+    const editor = await atom.workspace.open(cawsvpath);
+    const messages = await lint(editor);
+    const messageText = '<a href="' +
+      'https://github.com/brigade/haml-lint/blob/master/lib/haml_lint/linter/README.md' +
+      '#classattributewithstaticvalue">ClassAttributeWithStaticValue</a>: ' +
+      'Avoid defining `class` in attributes hash for static class names';
 
-    it('finds at least one message', () => {
-      waitsForPromise(() =>
-        lint(editor).then(messages =>
-          expect(messages.length).toBeGreaterThan(0)));
-    });
-
-    it('verifies the first message', () => {
-      waitsForPromise(() => {
-        const messageText = '<a href="' +
-          'https://github.com/brigade/haml-lint/blob/master/lib/haml_lint/linter/README.md' +
-          '#classattributewithstaticvalue">ClassAttributeWithStaticValue</a>: ' +
-          'Avoid defining `class` in attributes hash for static class names';
-        return lint(editor).then((messages) => {
-          expect(messages[0].type).toBe('Warning');
-          expect(messages[0].text).not.toBeDefined();
-          expect(messages[0].html).toBe(messageText);
-          expect(messages[0].filePath).toBe(cawsvpath);
-          expect(messages[0].range).toEqual([[0, 0], [0, 23]]);
-        });
-      });
-    });
+    expect(messages.length).toBe(1);
+    expect(messages[0].type).toBe('Warning');
+    expect(messages[0].text).not.toBeDefined();
+    expect(messages[0].html).toBe(messageText);
+    expect(messages[0].filePath).toBe(cawsvpath);
+    expect(messages[0].range).toEqual([[0, 0], [0, 23]]);
   });
 
-  it('finds nothing wrong with a valid file', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(validPath).then(editor =>
-        lint(editor).then(messages =>
-          expect(messages.length).toBe(0))));
+  it('finds nothing wrong with a valid file', async () => {
+    const editor = await atom.workspace.open(validPath);
+    const messages = await lint(editor);
+
+    expect(messages.length).toBe(0);
   });
 
-  it('finds nothing wrong with an empty file', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(emptyPath).then(editor =>
-        lint(editor).then(messages =>
-          expect(messages.length).toBe(0))));
+  it('finds nothing wrong with an empty file', async () => {
+    const editor = await atom.workspace.open(emptyPath);
+    const messages = await lint(editor);
+
+    expect(messages.length).toBe(0);
   });
 });


### PR DESCRIPTION
Bring in `jasmine-fix` to allow the use of `async`/`await` in the specs and refactor them to take advantage of this.