### PR TITLE
Update Ruby versions in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,19 @@ language: ruby
 matrix:
   include:
     - os: linux
-      rvm: 2.1.8
+      rvm: 2.3.5
       env: ATOM_CHANNEL=stable
 
     - os: linux
-      rvm: 2.2.6
+      rvm: 2.4.0
       env: ATOM_CHANNEL=stable
 
     - os: linux
-      rvm: 2.3.3
+      rvm: 2.5.0
       env: ATOM_CHANNEL=stable
 
     - os: linux
-      rvm: 2.3.3
+      rvm: 2.5.0
       env: ATOM_CHANNEL=beta
 
 env:


### PR DESCRIPTION
The Ruby versions used for the CI builds were no longer compatible with `haml-lint`.