### PR TITLE
Fix exitCode issue

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -77,7 +77,8 @@ export default {
 
         const messages = [];
 
-        if (output.exitCode !== 0) {
+        // 65 is the exit code from haml-lint if linters triggered
+        if (output.exitCode !== 0 && output.exitCode !== 65) {
           if (output.stderr.toLowerCase().startsWith(warning)) {
             messages.push({
               severity: warning,

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "5.16.0",
     "eslint-config-airbnb-base": "13.1.0",
     "eslint-plugin-import": "2.17.2",
-    "jasmine-fix": "1.3.1"
+    "jasmine-fix": "^1.3.1"
   },
   "renovate": {
     "extends": [


### PR DESCRIPTION
`haml-lint` will exit with status code 65 when there are any lints that tripped.  The existing code incorrectly assumes that the return code will always be 0 even when lints fail.

I believe this fixes #169 