### PR TITLE
Fix Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,15 @@ language: ruby
 matrix:
   include:
     - os: linux
-      rvm: 2.3.5
+      rvm: 2.5.7
       env: ATOM_CHANNEL=stable
 
     - os: linux
-      rvm: 2.4.0
+      rvm: 2.6.5
       env: ATOM_CHANNEL=stable
 
     - os: linux
-      rvm: 2.5.0
-      env: ATOM_CHANNEL=stable
-
-    - os: linux
-      rvm: 2.5.0
+      rvm: 2.7.0-preview3
       env: ATOM_CHANNEL=beta
 
 env:

--- a/spec/fixtures/.haml-lint.yml
+++ b/spec/fixtures/.haml-lint.yml
@@ -2,4 +2,5 @@ linters:
   RuboCop:
     enabled: true
     ignored_cops:
-      - Layout/TrailingBlankLines
+      - Layout/TrailingEmptyLines
+      - Style/FrozenStringLiteralComment


### PR DESCRIPTION
Rubocop added a new default cop and renamed another.

Also, second commit fixes the fact that haml_lint dropped support for ruby < 2.4 so install an older package for that.